### PR TITLE
mention mpi4py dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ source .venv/bin/activate
 (.venv) # optionally install pytorch manually for your own specific env first...
 (.venv) python -m pip install -r requirements.txt
 ```
-### bitsandbytes
-```sh
-# choices: {cuda92, cuda 100, cuda101, cuda102, cuda110, cuda111, cuda113}
-# replace XXX with the respective number
-pip install bitsandbytes-cudaXXX
-```
-If you prefer to use `torch.optim.Adam`, you can just change `bnb` to `th` in the code.
 
 ## Usage
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Presently has all sorts of issues that are challenging to debug.
 
 
 ```sh
+sudo apt install libopenmpi-dev # On macOS: brew install mpich
 git clone https://github.com/afiaka87/glide-finetune.git
 cd glide-finetune/
 python3 -m venv .venv # create a virtual environment to keep global install clean.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ requests==2.26.0
 termcolor==1.1.0
 toml==0.10.2
 torch==1.10.1
+bitsandbytes-cuda102
 torchvision==0.11.2
 tornado==6.1
 tqdm==4.62.3


### PR DESCRIPTION
mpi4py installation will fail unless the user has this package installed.
Since MPI is not a ubiquitous dependency it should probably be mentioned.
Edit:
Since torch==1.10.1 is a requirement, and torch versions come with their own cuda versions (torch 1.10.1 uses cuda 10.2), I don't see a reason not to just include bitsandbytes-cuda102 in requirements.txt.

```sh
$ py -m venv .venv
$ source .venv/bin/activate
$ pip install torch==1.10.1
Collecting torch==1.10.1
  Downloading torch-1.10.1-cp39-cp39-manylinux1_x86_64.whl (881.9 MB)
     |████████████████████████████████| 881.9 MB 15 kB/s
Collecting typing-extensions
  Downloading typing_extensions-4.0.1-py3-none-any.whl (22 kB)
Installing collected packages: typing-extensions, torch
Successfully installed torch-1.10.1 typing-extensions-4.0.1
$ py -c "import torch; print(torch.__version__)"
1.10.1+cu102
```