### PR TITLE
Fixed half precision optimizer bug

### DIFF
--- a/train_glide.py
+++ b/train_glide.py
@@ -135,7 +135,13 @@ def run_glide_finetune(
         lr=learning_rate,
         weight_decay=adam_weight_decay,
     )
-
+    if use_fp16:
+        optimizer = th.optim.AdamW(
+            [x for x in glide_model.parameters() if x.requires_grad],
+            lr=learning_rate,
+            weight_decay=adam_weight_decay,
+            eps=1e-4,
+        )
     if not freeze_transformer: # if we want to train the transformer, we need to backpropagate through the diffusion model.
         glide_model.out.requires_grad_(True)
         glide_model.input_blocks.requires_grad_(True)


### PR DESCRIPTION
# Problem

In half precision, after the first iteration nan values start appearing regardless of input data or gradients since the adam optimizer breaks in float16. The discussion for that can be viewed [here](https://discuss.pytorch.org/t/adam-half-precision-nans/1765). 

# Solution

This can be fixed by setting the eps variable to 1e-4 instead of the default 1e-8. This is the only thing this pr does